### PR TITLE
Remove unneeded markup from vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,5 @@ import preact from '@preact/preset-vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  esbuild: {
-    jsxFactory: 'h',
-    jsxFragment: "Fragment",
-    jsxInject: 'import {h, Fragment } from "preact"'
-  },
   plugins: [preact()],
-  alias: {
-    react: 'preact/compat',
-  },
 })


### PR DESCRIPTION
Preact preset automatically inserts the required JSX and stuff, and aliases React to preact compat, so you can get rid of extra stuff