### PR TITLE
Add autofocus to search bar

### DIFF
--- a/src/Components/StartMenu/SearchBar/index.tsx
+++ b/src/Components/StartMenu/SearchBar/index.tsx
@@ -11,6 +11,7 @@ export const SearchBar = () => {
         class={styles.search_input}
         type="text"
         placeholder="Type here to search"
+        autofocus
       />
     </div>
   );

--- a/src/Components/StartMenu/SearchBar/index.tsx
+++ b/src/Components/StartMenu/SearchBar/index.tsx
@@ -11,7 +11,7 @@ export const SearchBar = () => {
         class={styles.search_input}
         type="text"
         placeholder="Type here to search"
-        autofocus
+        autoFocus
       />
     </div>
   );


### PR DESCRIPTION
Love the project!
This is a minor minor change: I just added autofocus to the search-bar so whenever you open the task menu you can automatically start typing without having to click on the search bar first, just like in the real windows.