### PR TITLE
Removed warning for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Some similar, but super awesome projects!
 - [Ubuntu Web](https://vivek9patel.github.io/) by [Vivek Patel](https://github.com/vivek9patel/vivek9patel.github.io)
 - [Windows 11 web, but with no-code](https://windows11.webflow.io/) by [Manivannan](https://twitter.com/BeingMani97)
 
-### Known Issues
-
-- Blur not working in Firefox browser.
-
 #### Solution:-
 
 1. Open `about:config` in your firefox browser.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,24 +2,4 @@ import "./index.css";
 import { Desktop } from "./Views/Desktop";
 import { render } from "preact";
 
-// @ts-ignore
-const isFirefox = typeof InstallTrigger !== "undefined";
-const hidePrompt = localStorage.getItem("hidePrompt");
-
-if (isFirefox && hidePrompt !== "true") {
-  let open =
-    confirm(`Hi, It looks like you're using Firefox. Sadly the lovely blur effect isn't avaiable in Firefox by default.
-You may open the site in chrome instead or click OK to open a guide on how to enable blur in firefox.
-`);
-  if (open) {
-    window
-      .open(
-        "https://github.com/PiyushSuthar/Windows-11-Web#known-issues",
-        "_blank"
-      )
-      ?.focus();
-    localStorage.setItem("hidePrompt", "true");
-  }
-}
 render(<Desktop />, document.getElementById("root")!);
-


### PR DESCRIPTION
Backdrop filter is supported since Firefox 103. With Firefox 107 being the latest stable release, it seems only fitting to remove this message.

https://caniuse.com/css-backdrop-filter